### PR TITLE
Add first-response-time endpoint

### DIFF
--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -46,5 +46,10 @@ class DataQualityResponse(BaseModel):
     )
 
 
+class IssueFirstResponseTimeResponse(BaseModel):
+    repository: str
+    average_response_time_seconds: float
+    average_response_time_readable: str
+
 class ErrorResponse(BaseModel):
     detail: str 


### PR DESCRIPTION
This PR add new API:

    /issues/first-response-time   that returns average time between an issue being opened and the first comment
